### PR TITLE
fix(feed): correct site `url` in feed metadata

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,7 +6,7 @@ subtitle: sarah young
 description: >-
  sre | dev | historian
 baseurl: ""
-url: http:sarahseewhy.github.io
+url: https://www.sarahyoung.tech/
 username: sarahseewhy
 email: sarahseewhy@gmail.com
 # Links


### PR DESCRIPTION
When following the existing RSS feed, none of the generated URLs
are correct, which means following a link to a post in a reader doesn't
work.

Not only does this add the needed slashes (`//`), but also points to the
HTTPS URL for the site's primary domain, rather than GitHub Pages.

---

As someone who's followed your feed for a while, I've meant to report this! But I found I could fix it, so that's even better 👏🏼

Note that this _may_ end up fixing a couple of TODOs around the `baseurl` in the README - may be worth checking if it has
